### PR TITLE
fix: per-project gitleaks output files

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -126,7 +126,7 @@ jobs:
           ref: ${{ github.head_ref }}
       - name: Get current timestamp
         id: timestamp
-        run: echo "time=$(date +%s)" >> $GITHUB_OUTPUT
+        run: echo "time=$(date +%s)" >> "$GITHUB_OUTPUT"
       - name: Scan for secrets
         env:
           PROJECT_FOLDER: ${{ inputs.project_folder }}


### PR DESCRIPTION
Use the project_folder to namespace the gitleaks.csv output.

Avoids this error: 

>  Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run