### PR TITLE
Support tagging based on .version in Chart.yaml

### DIFF
--- a/scripts/tagging-lib.sh
+++ b/scripts/tagging-lib.sh
@@ -63,6 +63,12 @@ function read_version {
     NEW_VERSION=$(yq .version "$VERSIONFILE")
     TAG_VERSION=$NEW_VERSION
 
+  elif [ -f "Chart.yaml" ]
+  then
+    VERSIONFILE="Chart.yaml"
+    NEW_VERSION=$(yq .version "$VERSIONFILE")
+    TAG_VERSION=$NEW_VERSION
+
   else
     echo "ERROR: No versioning file found!"
     FAIL_VALIDATION=1


### PR DESCRIPTION
Local test result looks good.
![2025-04-14-10-04-56](https://github.com/user-attachments/assets/c8522975-f05a-410a-a998-b3ffe33eafe1)
