### PR TITLE
Look for `dictionary_append.txt` in `docs`

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -217,8 +217,8 @@ jobs:
             if [ "${SIMPLE_MODE}" == 'true' ]; then
               # Override any existing files with template
               cp -rf "${GITHUB_WORKSPACE}"/_template/* .
-              if [ -f "dictionary_append.txt" ]; then
-                cat "dictionary_append.txt" >> "dict.txt"
+              if [ -f "docs/dictionary_append.txt" ]; then
+                cat "docs/dictionary_append.txt" >> "dict.txt"
               fi
             fi
             echo "Building branch: ${branch}"


### PR DESCRIPTION
The `dictionary_append.txt` file is located in `docs` rather than the base directory.  For example: https://github.com/open-edge-platform/edge-ai-suites/tree/main/metro-ai-suite/search-image-by-image/docs

Correct this path.