### PR TITLE
Use proper `repo_project` as a cache key

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -331,10 +331,10 @@ jobs:
             ${{ env.GOCACHE }}
             ${{ env.GOMODCACHE }}
             ~/.cache/golangci-lint
-          key: ${{ env.REPO_PROJECT }}-${{ runner.os }}-go-${{ env.GOLANG_VER }}-${{ hashFiles('**/go.mod') }}
+          key: ${{ needs.sanitize-project-folder.outputs.repo_project }}-${{ runner.os }}-go-${{ env.GOLANG_VER }}-${{ hashFiles('**/go.mod') }}
           restore-keys: |
-            ${{ env.REPO_PROJECT }}-${{ runner.os }}-go-${{ env.GOLANG_VER }}-
-            ${{ env.REPO_PROJECT }}-${{ runner.os }}-go-
+            ${{ needs.sanitize-project-folder.outputs.repo_project }}-${{ runner.os }}-go-${{ env.GOLANG_VER }}-
+            ${{ needs.sanitize-project-folder.outputs.repo_project }}-${{ runner.os }}-go-
 
       - name: Build Code
         if: ${{ inputs.run_build }}


### PR DESCRIPTION
`env.REPO_PROJECT` was empty after https://github.com/open-edge-platform/orch-ci/pull/25 has been merged