### PR TITLE
Return empty json array if no projects are changed

### DIFF
--- a/discover-changed-subfolders/action.yml
+++ b/discover-changed-subfolders/action.yml
@@ -62,8 +62,13 @@ runs:
         # Debugging: Print the changed projects array
         echo "Changed Projects Array: ${changed_projects[@]}"
 
-        # Convert the array to a JSON
-        changed_projects_list=$(printf '%s\n' "${changed_projects[@]}" | jq -R . | jq -s -c .)
+        if [ -n "$changed_projects" ]; then
+            # Convert the array to a JSON
+            changed_projects_list=$(printf '%s\n' "${changed_projects[@]}" | jq -R . | jq -s -c .)
+        else
+            # Set to an empty JSON array if no projects are changed
+            changed_projects_list="[]"
+        fi
 
         # Debugging: Print the changed projects list
         echo "Changed Projects List: $changed_projects_list"


### PR DESCRIPTION
`pre checks orch-ci/discover-changed-subfolders` job returns an array with 1 element (empty string) and thus the `pre-merge-pipeline` runs with 1 element but it's an empty string as the project folder. The following scenarios:

INVALID: array with 1 element `[""]` is reproduced when these 2 conditions are met: 
1. no subfolder is changed AND 
2. none of the folders are changed in `folders_to_remove='[".github",".reuse","LICENSES"]'` AND
3. a file is changed on root dir so not subdirectories

see https://github.com/open-edge-platform/app-orch-deployment/actions/runs/14487425630/job/40636158537?pr=35 for invalid

VALID: array with 1 element `["<folder_name_from list_below>"]` is reproduced when the 2 conditions are met:
1. no subfolder is changed AND 
2. at least 1 folder is changed from `folders_to_remove='[".github",".reuse","LICENSES"]'` AND
3. a file is changed on root dir so not subdirectories

**Note:** In a different run, one of the folders in the list gets removed from list

VALID: array with 1 element `["<folder_name_from list_below>", "<subfolder>"]` is reproduced when the 2 conditions are met:
1. subfolder is changed AND 
2. at least 1 folder is changed from `folders_to_remove='[".github",".reuse","LICENSES"]'` AND
3. a file is changed on root dir so not subdirectories

**Note:** In a different run, one of the folders in the list gets removed from list
