### PR TITLE
Update trivy config path

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -126,6 +126,11 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: ""
         type: string
+      trivy_config_path:
+        description: "Path to trivy configuration file"
+        required: false
+        default: "trivy.yaml"
+        type: string
 permissions:
   contents: write
 jobs:
@@ -215,7 +220,7 @@ jobs:
           format: 'table'
           severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
           ignore-unfixed: true
-          trivy-config: trivy.yaml
+          trivy-config: ${{ inputs.trivy_config_path }}
           scanners: 'vuln,misconfig,secret'
           output: "trivy_scan_report-${{ needs.sanitize-project-folder.outputs.sanitized_report_path }}.txt"
       - name: Upload Trivy Scan Report
@@ -239,7 +244,7 @@ jobs:
           format: 'table'
           severity: 'HIGH,CRITICAL'
           ignore-unfixed: false
-          trivy-config: ${{ inputs.project_folder }}/trivy.yaml
+          trivy-config: ${{ inputs.trivy_config_path }}
           scanners: 'vuln,misconfig,secret'
           exit-code: 1
   run-repo-pipelines:


### PR DESCRIPTION
There may be dirs or files needed to be skipped by trivy scan which are defined in the trivy configuation file. The trivy config file is not found when running job `trivy-critical-scan`, but the prior job `trivy-filesystem-scan` finds the config file and uses it. Both jobs use different path to locate the config file.

This change will keep default path to `trivy.yaml` and allow value to be configured.