### PR TITLE
Fix Scorecard workflow verification for supply-chain security

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -226,7 +226,7 @@ jobs:
           path: raw-scorecard.sarif
   process-scorecard-results:
     runs-on: ubuntu-latest
-    needs: scorecard
+    needs: scorecard, sanitize-project-folder
     steps:
       - name: Download raw results
         uses: actions/download-artifact@v4

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -219,6 +219,19 @@ jobs:
           results_format: sarif
           repo_token: ${{ secrets.SYS_ORCH_GITHUB }}
           publish_results: true
+      - name: Upload raw Scorecard Results as Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: raw-scorecard-results
+          path: raw-scorecard.sarif
+  process-scorecard-results:
+    runs-on: ubuntu-latest
+    needs: scorecard
+    steps:
+      - name: Download raw results
+        uses: actions/download-artifact@v4
+        with:
+          name: raw-scorecard-results
       - name: Remove Fuzzing check from SARIF
         run: |
           jq 'del(.runs[].results[] | select(.ruleId=="Fuzzing"))

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -226,7 +226,7 @@ jobs:
           path: raw-scorecard.sarif
   process-scorecard-results:
     runs-on: ubuntu-latest
-    needs: scorecard, sanitize-project-folder
+    needs: [scorecard, sanitize-project-folder]
     steps:
       - name: Download raw results
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Pull Request Template

<!---
  SPDX-FileCopyrightText: (C) 2025 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author: Alexandru Dimofte
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the
    checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable
    for the PR change.
-->

## Description

Must only use actions (i.e., steps that have uses:) and cannot have any run: commands.
Initial observed issue was: 
2025/10/08 07:55:26 retrying in 3s...
2025/10/08 07:55:30 error sending scorecard results to webapp: http response 400, status: 400 Bad Request, error: {"code":400,"message":"workflow verification failed: scorecard job must only have steps with `uses`, see https://github.com/ossf/scorecard-action#workflow-restrictions for details."}

2025/10/08 07:55:30 retrying in 10s...
2025/10/08 07:55:40 error processing signature: error sending scorecard results to webapp: http response 400, status: 400 Bad Request, error: {"code":400,"message":"workflow verification failed: scorecard job must only have steps with `uses`, see https://github.com/ossf/scorecard-action#workflow-restrictions for details."}

Fixes # (issue)

## Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information, and how they are used in the project.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions
so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code
