### PR TITLE
Update pre-merge.yml to continue on error for Trivy

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -846,6 +846,7 @@ jobs:
           if grep -E '│ *(HIGH|CRITICAL) *│.*│ *FAIL *│' trivy_cis-${{ env.sanitized_image_name }}.txt; then
             echo "❌ Found HIGH/CRITICAL CIS failures"
             cat trivy_cis-${{ env.sanitized_image_name }}.txt
+            exit 1
           else
             echo "✅ No HIGH/CRITICAL CIS failures"
           fi

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -908,4 +908,3 @@ jobs:
         if: ${{ always() }}
         run: |
           cat trivy-image-${{ env.sanitized_image_name }}-high-critical.sarif || echo "No report found"
-      

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -873,6 +873,7 @@ jobs:
             --format sarif \
             --ignore-unfixed \
             --severity HIGH,CRITICAL \
+            --exit-code 1 \
             --output "trivy-image-${{ env.sanitized_image_name }}-high-critical.sarif" \
             --config ${{ inputs.trivy_config_path }} \
             ${{ matrix.image }}

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -305,6 +305,7 @@ jobs:
           persist-credentials: false
       - name: Run Trivy Filesystem Scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # 0.35.0
+        continue-on-error: true
         with:
           scan-type: 'fs'
           scan-ref: ${{ inputs.project_folder }}
@@ -345,6 +346,7 @@ jobs:
           persist-credentials: false
       - name: Run Trivy Critical Filesystem Scan
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # 0.35.0
+        continue-on-error: true
         with:
           scan-type: 'fs'
           scan-ref: ${{ inputs.project_folder }}
@@ -353,7 +355,6 @@ jobs:
           ignore-unfixed: false
           trivy-config: ${{ inputs.trivy_config_path }}
           scanners: 'vuln,misconfig,secret'
-          exit-code: 1
   trivy-config-scan:
     permissions:
       contents: read
@@ -367,6 +368,7 @@ jobs:
 
       - name: Run Trivy Config Scan (Dockerfile / IaC)
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        continue-on-error: true
         with:
           scan-type: 'config'
           scan-ref: ${{ inputs.project_folder }}
@@ -833,6 +835,7 @@ jobs:
           version: 'v${{ env.TRIVY_VER }}'
 
       - name: Scan Image for Docker CIS compliance
+        continue-on-error: true
         run: |
           trivy image \
             --compliance docker-cis-1.6.0 \
@@ -843,13 +846,9 @@ jobs:
           if grep -E '│ *(HIGH|CRITICAL) *│.*│ *FAIL *│' trivy_cis-${{ env.sanitized_image_name }}.txt; then
             echo "❌ Found HIGH/CRITICAL CIS failures"
             cat trivy_cis-${{ env.sanitized_image_name }}.txt
-            EXIT_CODE=1
           else
             echo "✅ No HIGH/CRITICAL CIS failures"
-            EXIT_CODE=0
           fi
-          echo "TRIVY_EXIT_CODE=$EXIT_CODE" >> $GITHUB_ENV
-          exit 0
 
       - name: Upload CIS Scan Report
         if: always()
@@ -859,32 +858,22 @@ jobs:
           path: trivy_cis-${{ env.sanitized_image_name }}.txt
           if-no-files-found: warn
 
-      - name: Fail if Trivy CIS found issues
-        if: env.TRIVY_EXIT_CODE != '0'
-        run: |
-          echo "Trivy found HIGH/CRITICAL issues"
-          exit 1
-        continue-on-error: ${{ inputs.ignore_trivy_fail }}
-
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
       - name: Scan Image for High/Critical Issues (Trivy)
+        continue-on-error: true
         run: |
           set +e
           trivy image \
             --format sarif \
             --ignore-unfixed \
             --severity HIGH,CRITICAL \
-            --exit-code 1 \
             --output "trivy-image-${{ env.sanitized_image_name }}-high-critical.sarif" \
             --config ${{ inputs.trivy_config_path }} \
             ${{ matrix.image }}
-
-          EXIT_CODE=$?
-          echo "TRIVY_VULN_EXIT_CODE=$EXIT_CODE" >> $GITHUB_ENV
 
           # Print the sarif file if it exists
           if [ -f "trivy-image-${{ env.sanitized_image_name }}-high-critical.sarif" ]; then
@@ -892,8 +881,6 @@ jobs:
             sed -n '1,200p' "trivy-image-${{ env.sanitized_image_name }}-high-critical.sarif"
             echo "::endgroup::"
           fi
-
-          exit 0
 
       - name: Tag Trivy SARIF results
         run: |
@@ -921,10 +908,4 @@ jobs:
         if: ${{ always() }}
         run: |
           cat trivy-image-${{ env.sanitized_image_name }}-high-critical.sarif || echo "No report found"
-
-      - name: Fail if Trivy vuln scan found high/critical issues
-        if: env.TRIVY_VULN_EXIT_CODE != '0'
-        run: |
-          echo "Trivy vulnerability scan failed"
-          exit 1
-        continue-on-error: ${{ inputs.ignore_trivy_fail }}
+      

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -873,7 +873,7 @@ jobs:
             --severity HIGH,CRITICAL \
             --output "trivy-image-${{ env.sanitized_image_name }}-high-critical.sarif" \
             --config ${{ inputs.trivy_config_path }} \
-            ${{ matrix.image }}  
+            ${{ matrix.image }}
 
       - name: Tag Trivy SARIF results
         run: |

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -873,14 +873,7 @@ jobs:
             --severity HIGH,CRITICAL \
             --output "trivy-image-${{ env.sanitized_image_name }}-high-critical.sarif" \
             --config ${{ inputs.trivy_config_path }} \
-            ${{ matrix.image }}
-
-          # Print the sarif file if it exists
-          if [ -f "trivy-image-${{ env.sanitized_image_name }}-high-critical.sarif" ]; then
-            echo "::group::Trivy SARIF (first 200 lines)"
-            sed -n '1,200p' "trivy-image-${{ env.sanitized_image_name }}-high-critical.sarif"
-            echo "::endgroup::"
-          fi
+            ${{ matrix.image }}  
 
       - name: Tag Trivy SARIF results
         run: |

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -355,6 +355,7 @@ jobs:
           ignore-unfixed: false
           trivy-config: ${{ inputs.trivy_config_path }}
           scanners: 'vuln,misconfig,secret'
+          exit-code: 1
   trivy-config-scan:
     permissions:
       contents: read


### PR DESCRIPTION
This pull request updates the `.github/workflows/pre-merge.yml` workflow to make Trivy security and compliance scans non-blocking by allowing them to continue on error, and removes logic that previously failed the workflow on scan failures. This change ensures that Trivy scan results are still generated and uploaded, but will not cause the workflow to fail, making the CI process more resilient to scan issues.

Key changes:

**Trivy scan steps now non-blocking:**
- Added `continue-on-error: true` to all Trivy scan steps, including filesystem, config, and image scans, so that failures in these steps will not fail the workflow. [[1]](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109R308) [[2]](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109R349) [[3]](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109R371) [[4]](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109R838) [[5]](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109L862-L897)

**Removed workflow-failing logic:**
- Removed manual exit code handling and steps that failed the workflow if HIGH/CRITICAL issues were found in Trivy CIS or vulnerability scans. This includes removing the use of environment variables like `TRIVY_EXIT_CODE` and `TRIVY_VULN_EXIT_CODE` to control workflow failure. [[1]](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109L846-L852) [[2]](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109L862-L897) [[3]](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109L925-L930)

**Simplified scan configuration:**
- Removed the `exit-code: 1` configuration from Trivy scan steps, as failures are now handled by `continue-on-error`. [[1]](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109L356) [[2]](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109L862-L897)