### PR TITLE
Update pre-merge.yml to set trivy version

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -825,10 +825,7 @@ jobs:
       - name: Load tool versions (safe)
         shell: bash
         run: |
-          set -a
-          source .github/actions/bootstrap/VERSIONS
-          set +a
-          echo "TRIVY_VER=${TRIVY_VER}" >> "$GITHUB_ENV"
+          echo "TRIVY_VER=0.69.3" >> "$GITHUB_ENV"
 
       - name: Install Trivy
         uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514  # v0.2.5


### PR DESCRIPTION
This pull request makes a minor change to the pre-merge GitHub Actions workflow. Instead of sourcing the `TRIVY_VER` environment variable from an external file, the workflow now sets it directly to a specific version string.

* The `TRIVY_VER` environment variable is now set explicitly to `0.69.3` in the `.github/workflows/pre-merge.yml` workflow, rather than being sourced from `.github/actions/bootstrap/VERSIONS`.