### PR TITLE
Update pre-merge-orch-ci.yml to revert to using SHA's for Orch-CI references

### DIFF
--- a/.github/workflows/pre-merge-orch-ci.yml
+++ b/.github/workflows/pre-merge-orch-ci.yml
@@ -15,7 +15,7 @@ jobs:
   pre-merge:
     permissions:
       contents: read
-    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@2026.1.1
+    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@7f386e60209a8a37ef76dc29a3c46d6984cc1ce9
     with:
       run_version_check: true
       run_dep_version_check: false

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -283,7 +283,7 @@ jobs:
           path: ci
           persist-credentials: false
       - name: Gitleaks scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@2026.1.1
+        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@7f386e60209a8a37ef76dc29a3c46d6984cc1ce9
         with:
           scan-scope: changed
           source: ${INPUTS_PROJECT_FOLDER}
@@ -409,7 +409,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Bandit scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@2026.1.1
+        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@7f386e60209a8a37ef76dc29a3c46d6984cc1ce9
         with:
           scan-scope: "changed"
           severity-level: "HIGH"


### PR DESCRIPTION
This pull request updates references to specific workflow and security action versions in the GitHub Actions configuration files to use a new commit hash, ensuring consistency and alignment with the latest upstream changes.

**Workflow and Action Version Updates:**

* Updated the `pre-merge` workflow in `.github/workflows/pre-merge-orch-ci.yml` to reference `open-edge-platform/orch-ci/.github/workflows/pre-merge.yml` at commit `7f386e60209a8a37ef76dc29a3c46d6984cc1ce9` instead of the previous tag `2026.1.1`.
* Updated the `Gitleaks` and `Bandit` security scan actions in `.github/workflows/pre-merge.yml` to use the same specific commit hash (`7f386e60209a8a37ef76dc29a3c46d6984cc1ce9`) for `open-edge-platform/orch-ci/.github/actions/security/gitleaks` and `open-edge-platform/orch-ci/.github/actions/security/bandit`. [[1]](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109L286-R286) [[2]](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109L412-R412)