### PR TITLE
Verdict for Trivy trivy-filesystem and trivy-config scans in Code Sca…

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -329,6 +329,16 @@ jobs:
           ' trivy_scan_report-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}.sarif \
           > trivy_tagged.sarif \
           && mv trivy_tagged.sarif trivy_scan_report-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}.sarif
+
+      - name: Trivy FS Verdict
+        run: |
+          if jq -e '.runs[].results[]?.level == "error"' trivy_scan_report-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}.sarif > /dev/null; then
+            echo "HIGH/CRITICAL found in FS scan"
+          else
+            echo "No HIGH/CRITICAL found in FS scan"
+          fi
+          exit 0
+
       - name: Upload Trivy Scan Report
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
@@ -391,6 +401,15 @@ jobs:
           ' trivy-config-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}.sarif \
           > trivy_tagged.sarif \
           && mv trivy_tagged.sarif trivy-config-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}.sarif
+
+      - name: Trivy Config Verdict
+        run: |
+          if jq -e '.runs[].results[]?.level == "error"' trivy-config-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}.sarif > /dev/null; then
+            echo "HIGH/CRITICAL found in Config scan"
+          else
+            echo "No HIGH/CRITICAL found in Config scan"
+          fi
+          exit 0
 
       - name: Upload Trivy Config Scan Report (SDL419)
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -347,28 +347,6 @@ jobs:
         with:
           name: trivy-fs-scan-report-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}
           path: trivy_scan_report-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}.sarif
-  trivy-critical-scan:
-    permissions:
-      contents: read
-    runs-on: ubuntu-latest
-    needs: sanitize-project-folder
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Run Trivy Critical Filesystem Scan
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # 0.35.0
-        continue-on-error: true
-        with:
-          scan-type: 'fs'
-          scan-ref: ${{ inputs.project_folder }}
-          format: 'table'
-          severity: 'HIGH,CRITICAL'
-          ignore-unfixed: false
-          trivy-config: ${{ inputs.trivy_config_path }}
-          scanners: 'vuln,misconfig,secret'
-          exit-code: 1
   trivy-config-scan:
     permissions:
       contents: read

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -333,13 +333,14 @@ jobs:
           && mv trivy_tagged.sarif trivy_scan_report-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}.sarif
 
       - name: Trivy FS Verdict
+        continue-on-error: true
         run: |
           if jq -e '.runs[].results[]?.level == "error"' trivy_scan_report-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}.sarif > /dev/null; then
             echo "HIGH/CRITICAL found in FS scan"
+            exit 1
           else
             echo "No HIGH/CRITICAL found in FS scan"
           fi
-          exit 0
 
       - name: Upload Trivy Scan Report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
@@ -405,13 +406,14 @@ jobs:
           && mv trivy_tagged.sarif trivy-config-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}.sarif
 
       - name: Trivy Config Verdict
+        continue-on-error: true
         run: |
           if jq -e '.runs[].results[]?.level == "error"' trivy-config-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}.sarif > /dev/null; then
             echo "HIGH/CRITICAL found in Config scan"
+            exit 1
           else
             echo "No HIGH/CRITICAL found in Config scan"
           fi
-          exit 0
 
       - name: Upload Trivy Config Scan Report (SDL419)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -312,7 +312,7 @@ jobs:
           scan-type: 'fs'
           scan-ref: ${{ inputs.project_folder }}
           format: 'sarif'
-          severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+          severity: 'HIGH,CRITICAL'
           ignore-unfixed: true
           trivy-config: ${{ inputs.trivy_config_path }}
           scanners: 'vuln,secret'
@@ -365,7 +365,7 @@ jobs:
           scan-type: 'config'
           scan-ref: ${{ inputs.project_folder }}
           format: 'sarif'
-          severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
+          severity: 'HIGH,CRITICAL'
           trivy-config: ${{ inputs.trivy_config_path }}
           output: trivy-config-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}.sarif
       - name: Tag Trivy SARIF results


### PR DESCRIPTION
This pull request adds additional steps to the pre-merge GitHub Actions workflow to provide clear verdict messages after Trivy security scans. Specifically, it introduces steps that analyze the scan reports and output whether any HIGH/CRITICAL issues were found, improving the visibility of scan results.

Jira: 
https://jira.devtools.intel.com/browse/ITEP-90286 -  trivy-filesystem vs trivy-critical scans
https://jira.devtools.intel.com/browse/ITEP-90283 -  Verdict for Trivy trivy-filesystem and trivy-config scans in Code Scanning tab



**Enhancements to Trivy scan reporting:**

* Added a "Trivy FS Verdict" step that checks the Trivy filesystem scan SARIF report for errors and outputs a message indicating if HIGH/CRITICAL issues were found.
* Added a "Trivy Config Verdict" step that checks the Trivy configuration scan SARIF report for errors and outputs a message indicating if HIGH/CRITICAL issues were found.