### PR TITLE
Update pre-merge.yml use token cloning gitleaks

### DIFF
--- a/.github/actions/security/gitleaks/action.yml
+++ b/.github/actions/security/gitleaks/action.yml
@@ -94,6 +94,10 @@ inputs:
     description: "Whether to upload SARIF results to the GitHub Security tab"
     required: false
     default: "true"
+  github_token:
+    description: "GitHub token used for GitHub API calls / downloading releases"
+    required: false
+    default: ""
 
 outputs:
   exit_code:
@@ -116,7 +120,7 @@ runs:
       shell: bash
       env:
         INPUT_VERSION: ${{ inputs.version }}
-        GITHUB_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}
+        GITHUB_TOKEN: ${{ input.github_token }}
       run: |
         set -euo pipefail
         VER="${INPUT_VERSION}"

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -293,6 +293,7 @@ jobs:
           redact: "true"
           report_suffix: "-${{ env.SANITIZED_PROJECT_NAME }}"
           upload-sarif: "false"
+          github_token: ${{ secrets.SYS_EMF_GH_TOKEN }}
   trivy-filesystem-scan:
     permissions:
       contents: read


### PR DESCRIPTION
This pull request updates how the `GITHUB_TOKEN` is managed for the Gitleaks security action, making it more configurable and secure. The main changes introduce a new `github_token` input to the action, ensure the workflow passes the token explicitly, and update the action to use this input instead of a hardcoded secret.

**Security and configuration improvements:**

* [`.github/actions/security/gitleaks/action.yml`](diffhunk://#diff-2bbad4af4f49c7fb233f28341fb2f77f0b5934f7678d76667dcc4bc5a025dabeR97-R100): Added a new optional `github_token` input to allow specifying the GitHub token used for API calls and downloads, with an empty string as the default.
* [`.github/actions/security/gitleaks/action.yml`](diffhunk://#diff-2bbad4af4f49c7fb233f28341fb2f77f0b5934f7678d76667dcc4bc5a025dabeL119-R123): Updated the action to use the new `github_token` input for the `GITHUB_TOKEN` environment variable instead of referencing the secret directly.
* [`.github/workflows/pre-merge.yml`](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109R296): Modified the workflow to pass the `SYS_EMF_GH_TOKEN` secret explicitly as the `github_token` input to the Gitleaks action.