### PR TITLE
Update action.yml typo

### DIFF
--- a/.github/actions/security/gitleaks/action.yml
+++ b/.github/actions/security/gitleaks/action.yml
@@ -120,7 +120,7 @@ runs:
       shell: bash
       env:
         INPUT_VERSION: ${{ inputs.version }}
-        GITHUB_TOKEN: ${{ input.github_token }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       run: |
         set -euo pipefail
         VER="${INPUT_VERSION}"


### PR DESCRIPTION
This pull request corrects an environment variable reference in the `gitleaks` GitHub Action configuration to ensure the `GITHUB_TOKEN` input is properly passed.

- Bug fix:
  * [`.github/actions/security/gitleaks/action.yml`](diffhunk://#diff-2bbad4af4f49c7fb233f28341fb2f77f0b5934f7678d76667dcc4bc5a025dabeL123-R123): Changed `GITHUB_TOKEN` from `${{ input.github_token }}` to `${{ inputs.github_token }}` to fix the input variable reference.