### PR TITLE
Update action.yml revert gitleak GH-TOKEN

### DIFF
--- a/.github/actions/security/gitleaks/action.yml
+++ b/.github/actions/security/gitleaks/action.yml
@@ -127,8 +127,7 @@ runs:
 
         if [[ "$VER" == "latest" ]]; then
           # Resolve latest tag (e.g., v8.28.0) and strip the 'v' for the tarball name
-          VER=$(curl -s -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
+          VER=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
             | grep -Po '"tag_name":\s*"v\K[0-9.]+' || true)
           if [[ -z "$VER" ]]; then
             echo "::error::Failed to resolve latest Gitleaks version"
@@ -137,7 +136,7 @@ runs:
         fi
 
         echo "Installing Gitleaks version: $VER"
-        curl -sSL -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+        curl -sSL \
           -o /tmp/gitleaks.tar.gz \
           "https://github.com/gitleaks/gitleaks/releases/download/v${VER}/gitleaks_${VER}_linux_x64.tar.gz"
         sudo tar xf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks


### PR DESCRIPTION
This pull request updates the way the Gitleaks version is resolved and downloaded in the custom GitHub Action configuration. The main change is the removal of GitHub API authentication when fetching release information and downloading the Gitleaks binary.

Security and dependency management updates:

* Removed the use of the `GITHUB_TOKEN` for authentication when querying the GitHub API for the latest Gitleaks release version in `.github/actions/security/gitleaks/action.yml`.
* Removed the `GITHUB_TOKEN` authorization header from the `curl` command used to download the Gitleaks binary tarball in `.github/actions/security/gitleaks/action.yml`.