### PR TITLE
update orch-ci sha

### DIFF
--- a/.github/workflows/pre-merge-orch-ci.yml
+++ b/.github/workflows/pre-merge-orch-ci.yml
@@ -15,7 +15,7 @@ jobs:
   pre-merge:
     permissions:
       contents: read
-    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@610eb6a51bf2b571cd900f62e2d9bd390b5a0703
+    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@229bec6c547e8477a535fac6fac0614bc1b6103b
     with:
       run_version_check: true
       run_dep_version_check: false

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -284,7 +284,7 @@ jobs:
           path: ci
           persist-credentials: false
       - name: Gitleaks scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@61e443ff1d4db60654dadaba65ff93a4af49a5f8
+        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@229bec6c547e8477a535fac6fac0614bc1b6103b
         with:
           scan-scope: changed
           source: ${INPUTS_PROJECT_FOLDER}
@@ -411,7 +411,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Bandit scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@7f386e60209a8a37ef76dc29a3c46d6984cc1ce9
+        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@229bec6c547e8477a535fac6fac0614bc1b6103b
         with:
           scan-scope: "changed"
           severity-level: "HIGH"


### PR DESCRIPTION
This pull request updates the references to shared GitHub Actions and workflows to use a newer commit hash, ensuring that the latest versions of these actions are used in CI processes. The changes focus on keeping security and workflow automation tools up to date.

**CI/CD Workflow Updates:**

* Updated the `pre-merge` job in `.github/workflows/pre-merge-orch-ci.yml` to use the latest commit (`229bec6c547e8477a535fac6fac0614bc1b6103b`) of the shared `pre-merge.yml` workflow.

**Security Action Updates:**

* Updated the `Gitleaks` security scan action in `.github/workflows/pre-merge.yml` to use the latest commit (`229bec6c547e8477a535fac6fac0614bc1b6103b`).
* Updated the `Bandit` security scan action in `.github/workflows/pre-merge.yml` to use the latest commit (`229bec6c547e8477a535fac6fac0614bc1b6103b`).