### PR TITLE
Use tags for Orch-CI reference 

### DIFF
--- a/.github/workflows/pre-merge-orch-ci.yml
+++ b/.github/workflows/pre-merge-orch-ci.yml
@@ -15,7 +15,7 @@ jobs:
   pre-merge:
     permissions:
       contents: read
-    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@610eb6a51bf2b571cd900f62e2d9bd390b5a0703
+    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@229bec6c547e8477a535fac6fac0614bc1b6103b
     with:
       run_version_check: true
       run_dep_version_check: false

--- a/.github/workflows/pre-merge-orch-ci.yml
+++ b/.github/workflows/pre-merge-orch-ci.yml
@@ -15,7 +15,7 @@ jobs:
   pre-merge:
     permissions:
       contents: read
-    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@229bec6c547e8477a535fac6fac0614bc1b6103b
+    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@2026.1.1
     with:
       run_version_check: true
       run_dep_version_check: false

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -284,7 +284,7 @@ jobs:
           path: ci
           persist-credentials: false
       - name: Gitleaks scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@229bec6c547e8477a535fac6fac0614bc1b6103b
+        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@2026.1.1
         with:
           scan-scope: changed
           source: ${INPUTS_PROJECT_FOLDER}
@@ -411,7 +411,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Bandit scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@229bec6c547e8477a535fac6fac0614bc1b6103b
+        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@2026.1.1
         with:
           scan-scope: "changed"
           severity-level: "HIGH"

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -284,7 +284,7 @@ jobs:
           path: ci
           persist-credentials: false
       - name: Gitleaks scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@61e443ff1d4db60654dadaba65ff93a4af49a5f8
+        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@229bec6c547e8477a535fac6fac0614bc1b6103b
         with:
           scan-scope: changed
           source: ${INPUTS_PROJECT_FOLDER}
@@ -411,7 +411,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Bandit scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@7f386e60209a8a37ef76dc29a3c46d6984cc1ce9
+        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@229bec6c547e8477a535fac6fac0614bc1b6103b
         with:
           scan-scope: "changed"
           severity-level: "HIGH"


### PR DESCRIPTION
This pull request updates the CI workflow to use the latest `2026.1.1` version of shared workflow and security action dependencies. This ensures that the pre-merge checks and security scans use the most up-to-date logic and fixes from the upstream repository.

**CI/CD Dependency Updates:**

* [`.github/workflows/pre-merge-orch-ci.yml`](diffhunk://#diff-5cc9733bfa68b1e46c67c612c36095a0d66582bc813b031c9cf4261a0eae729cL18-R18): Updated the `pre-merge` workflow to use `open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@2026.1.1` instead of a specific commit hash.
* [`.github/workflows/pre-merge.yml`](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109L287-R287): Updated the `Gitleaks` security scan action to use version `2026.1.1` of the action.
* [`.github/workflows/pre-merge.yml`](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109L414-R414): Updated the `Bandit` security scan action to use version `2026.1.1` of the action.