### PR TITLE
Replace tags with shas for orch-ci

### DIFF
--- a/.github/workflows/pre-merge-orch-ci.yml
+++ b/.github/workflows/pre-merge-orch-ci.yml
@@ -15,7 +15,7 @@ jobs:
   pre-merge:
     permissions:
       contents: read
-    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@2026.1.1
+    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@ca0841de53d0e70b4934696601a748bff06fe6d9 # 2026.1.1
     with:
       run_version_check: true
       run_dep_version_check: false

--- a/.github/workflows/pre-merge-orch-ci.yml
+++ b/.github/workflows/pre-merge-orch-ci.yml
@@ -15,7 +15,7 @@ jobs:
   pre-merge:
     permissions:
       contents: read
-    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@ca0841de53d0e70b4934696601a748bff06fe6d9 # 2026.1.1
+    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@ca0841de53d0e70b4934696601a748bff06fe6d9  # 2026.1.1
     with:
       run_version_check: true
       run_dep_version_check: false

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -284,7 +284,7 @@ jobs:
           path: ci
           persist-credentials: false
       - name: Gitleaks scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@ca0841de53d0e70b4934696601a748bff06fe6d9 # 2026.1.1
+        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@ca0841de53d0e70b4934696601a748bff06fe6d9  # 2026.1.1
         with:
           scan-scope: changed
           source: ${INPUTS_PROJECT_FOLDER}
@@ -410,7 +410,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Bandit scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@ca0841de53d0e70b4934696601a748bff06fe6d9 # 2026.1.1
+        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@ca0841de53d0e70b4934696601a748bff06fe6d9  # 2026.1.1
         with:
           scan-scope: "changed"
           severity-level: "HIGH"

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -284,7 +284,7 @@ jobs:
           path: ci
           persist-credentials: false
       - name: Gitleaks scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@2026.1.1
+        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@ca0841de53d0e70b4934696601a748bff06fe6d9 # 2026.1.1
         with:
           scan-scope: changed
           source: ${INPUTS_PROJECT_FOLDER}
@@ -410,7 +410,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Bandit scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@2026.1.1
+        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@ca0841de53d0e70b4934696601a748bff06fe6d9 # 2026.1.1
         with:
           scan-scope: "changed"
           severity-level: "HIGH"


### PR DESCRIPTION
This pull request updates the references to shared workflow and security action versions in the GitHub Actions workflows. The main change is switching from the version tag `2026.1.1` to a specific commit hash for improved reproducibility and traceability.

**CI Workflow Updates:**

* Updated the `pre-merge` job in `.github/workflows/pre-merge-orch-ci.yml` to use the shared workflow at commit `ca0841de53d0e70b4934696601a748bff06fe6d9` instead of the version tag `2026.1.1`.

**Security Action Updates:**

* Updated the `Gitleaks` security scan action in `.github/workflows/pre-merge.yml` to reference the same commit hash instead of the version tag.
* Updated the `Bandit` security scan action in `.github/workflows/pre-merge.yml` to reference the same commit hash instead of the version tag.