### PR TITLE
Fixed some of the Nodejs24 warnings

### DIFF
--- a/.github/actions/security/gitleaks/action.yml
+++ b/.github/actions/security/gitleaks/action.yml
@@ -116,7 +116,7 @@ runs:
       uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323  # v47.0.5
 
     - name: Checkout orch-ci (for VERSIONS)
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: open-edge-platform/orch-ci
         path: orch-ci

--- a/.github/actions/security/trivy/action.yml
+++ b/.github/actions/security/trivy/action.yml
@@ -139,7 +139,7 @@ runs:
           trivy-db-${{ runner.os }}-
 
     - name: Checkout orch-ci (for VERSIONS)
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: open-edge-platform/orch-ci
         path: orch-ci

--- a/.github/actions/security/zizmor/action.yml
+++ b/.github/actions/security/zizmor/action.yml
@@ -11,7 +11,7 @@
 #  zizmor:
 #    runs-on: ubuntu-latest
 #    steps:
-#      - uses: actions/checkout@v4
+#      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 #      - name: Run zizmor scan
 #        uses: ./.github/actions/security/zizmor
 #        with:

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -206,7 +206,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Trivy Filesystem Scan
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
         with:
           scan-type: 'fs'
           scan-ref: ${{ inputs.project_folder }}
@@ -231,7 +231,7 @@ jobs:
           > trivy_tagged.sarif \
           && mv trivy_tagged.sarif trivy_scan_report-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}.sarif
       - name: Run Trivy SBOM
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
         with:
           scan-type: 'fs'
           format: 'spdx-json'
@@ -264,7 +264,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Trivy Config Scan (Dockerfile / IaC)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
         with:
           scan-type: 'config'
           scan-ref: ${{ inputs.project_folder }}
@@ -320,7 +320,7 @@ jobs:
           path: ci
           persist-credentials: false
       - name: Gitleaks scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@b5930c48c1fcdb6b34ffbcd465cff96dabfbde70  # v2026.0.17
+        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@bf82f7924caaac6ba2f388b6ec6ac4edd65f48ee  # 2026.1.1
         with:
           scan-scope: all
           config_path: ci/.gitleaks.toml
@@ -364,7 +364,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Bandit scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@b5930c48c1fcdb6b34ffbcd465cff96dabfbde70  # 2026.0.17
+        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@bf82f7924caaac6ba2f388b6ec6ac4edd65f48ee  # 2026.1.1
         with:
           scan-scope: "all"
           fail-on-findings: false
@@ -969,7 +969,7 @@ jobs:
 
       - name: Scan Image
         if: startsWith(matrix.image, '080137407410.dkr.ecr.')
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
         with:
           image-ref: ${{ matrix.image }}
           format: 'sarif'

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -306,7 +306,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Trivy Filesystem Scan
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
         continue-on-error: true
         with:
           scan-type: 'fs'
@@ -359,7 +359,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Trivy Config Scan (Dockerfile / IaC)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
         continue-on-error: true
         with:
           scan-type: 'config'

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -193,7 +193,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Trivy Filesystem Scan
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
         with:
           scan-type: 'fs'
           scan-ref: ${{ inputs.project_folder }}
@@ -240,7 +240,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Trivy Critical Filesystem Scan
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
         with:
           scan-type: 'fs'
           scan-ref: ${{ inputs.project_folder }}
@@ -264,7 +264,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Trivy Config Scan (Dockerfile / IaC)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
         with:
           scan-type: 'config'
           scan-ref: ${{ inputs.project_folder }}
@@ -327,7 +327,7 @@ jobs:
           echo "safe_name=$SAFE_NAME" >> $GITHUB_OUTPUT
 
       - name: Scan Docker Image
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
         with:
           image-ref: ${{ matrix.image }}
           format: 'sarif'


### PR DESCRIPTION
This pull request updates several security-related GitHub Actions to use newer, pinned versions for improved reliability and security. The main changes are version bumps for the Trivy, Gitleaks, and Bandit actions, as well as updating the `actions/checkout` step to a specific commit SHA. These updates ensure the workflows use the latest features and security patches.

**Security workflow updates:**

* Updated all references to `aquasecurity/trivy-action` from version `0.35.0` to `0.36.0` across `pre-merge.yml`, `post-merge.yml`, and `security-scans.yml` for filesystem, config, SBOM, and Docker image scans. [[1]](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109L309-R309) [[2]](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109L362-R362) [[3]](diffhunk://#diff-649dadd84b5d9938ac7f7a33a4020062fa437edcfc320554adf8bcf62c14602aL209-R209) [[4]](diffhunk://#diff-649dadd84b5d9938ac7f7a33a4020062fa437edcfc320554adf8bcf62c14602aL234-R234) [[5]](diffhunk://#diff-649dadd84b5d9938ac7f7a33a4020062fa437edcfc320554adf8bcf62c14602aL267-R267) [[6]](diffhunk://#diff-649dadd84b5d9938ac7f7a33a4020062fa437edcfc320554adf8bcf62c14602aL972-R972) [[7]](diffhunk://#diff-50ec92d8c0157063e0e7c5c1c500a248d412b372c39e400e34342f0385e91304L196-R196) [[8]](diffhunk://#diff-50ec92d8c0157063e0e7c5c1c500a248d412b372c39e400e34342f0385e91304L243-R243) [[9]](diffhunk://#diff-50ec92d8c0157063e0e7c5c1c500a248d412b372c39e400e34342f0385e91304L267-R267) [[10]](diffhunk://#diff-50ec92d8c0157063e0e7c5c1c500a248d412b372c39e400e34342f0385e91304L330-R330)
* Bumped `open-edge-platform/orch-ci/.github/actions/security/gitleaks` and `.github/actions/security/bandit` from `2026.0.17` to `2026.1.1` in `post-merge.yml`. [[1]](diffhunk://#diff-649dadd84b5d9938ac7f7a33a4020062fa437edcfc320554adf8bcf62c14602aL323-R323) [[2]](diffhunk://#diff-649dadd84b5d9938ac7f7a33a4020062fa437edcfc320554adf8bcf62c14602aL367-R367)

**Dependency pinning and checkout updates:**

* Updated `actions/checkout` in all relevant security action workflows to use a pinned commit SHA (`de0fac2e4500dabe0009e67214ff5f5447ce83dd`, corresponding to v6.0.2) instead of the floating `v4` tag, for reproducibility and security. [[1]](diffhunk://#diff-2bbad4af4f49c7fb233f28341fb2f77f0b5934f7678d76667dcc4bc5a025dabeL119-R119) [[2]](diffhunk://#diff-6a766d2851df6caab063f6687b949342ff88935081048943e9fa8e2c4ed0d3c0L142-R142) [[3]](diffhunk://#diff-c6ac4e2102268834d2cf26ebb529aac27cb35709b475a02f622c84d388a473ffL14-R14)

These changes help ensure that your CI/CD pipelines are using up-to-date and secure versions of critical scanning tools and dependencies.