### PR TITLE
Fix Trivy version issue in security_scans.yaml

### DIFF
--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -181,11 +181,16 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     needs: sanitize-project-folder
     steps:
+      - name: Checkout orch-ci (for VERSIONS)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: open-edge-platform/orch-ci
+          path: orch-ci
       - name: Load tool versions
         shell: bash
         run: |
           set -a
-          source .github/actions/bootstrap/VERSIONS
+          source orch-ci/.github/actions/bootstrap/VERSIONS
           set +a
           echo "TRIVY_VER=${TRIVY_VER}" >> "$GITHUB_ENV"
       - name: Checkout code


### PR DESCRIPTION
This pull request updates the way tool versions are loaded in the `security-scans.yml` workflow to improve maintainability and ensure the latest version information is used. The main change is to source the `VERSIONS` file from the `orch-ci` repository instead of the local repository.

**Workflow improvements:**

* The workflow now checks out the `open-edge-platform/orch-ci` repository at the start of the job to access the latest `VERSIONS` file.
* The `Load tool versions` step now sources `orch-ci/.github/actions/bootstrap/VERSIONS` instead of the local `.github/actions/bootstrap/VERSIONS`, ensuring that tool versioning is consistent with the shared CI configuration.