### PR TITLE
orch-ci bump sha versions

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -32,6 +32,6 @@ jobs:
           persist-credentials: false
 
       - name: Update pull requests
-        uses: open-edge-platform/orch-ci/.github/actions/pr_updater@3fc30e438875fee1b679268eef33fca33b3c7102  # 2026.0.17
+        uses: open-edge-platform/orch-ci/.github/actions/pr_updater@6fd47d2a79b1e7d4988d1a5df6585b29a76f65c4  # 2026.1.2
         with:
           github_token: ${{ secrets.SYS_EMF_GH_TOKEN }}

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -320,7 +320,7 @@ jobs:
           path: ci
           persist-credentials: false
       - name: Gitleaks scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@bf82f7924caaac6ba2f388b6ec6ac4edd65f48ee  # 2026.1.1
+        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@6fd47d2a79b1e7d4988d1a5df6585b29a76f65c4  # 2026.1.2
         with:
           scan-scope: all
           config_path: ci/.gitleaks.toml
@@ -364,7 +364,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Bandit scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@bf82f7924caaac6ba2f388b6ec6ac4edd65f48ee  # 2026.1.1
+        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@6fd47d2a79b1e7d4988d1a5df6585b29a76f65c4  # 2026.1.2
         with:
           scan-scope: "all"
           fail-on-findings: false

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1023,7 +1023,7 @@ jobs:
           ref: ${{ inputs.orch_ci_repo_ref }}
           persist-credentials: false
       - name: Run Version Update Action
-        uses: open-edge-platform/orch-ci/dev-version-update@b5930c48c1fcdb6b34ffbcd465cff96dabfbde70  # 2026.0.17
+        uses: open-edge-platform/orch-ci/dev-version-update@6fd47d2a79b1e7d4988d1a5df6585b29a76f65c4  # 2026.1.2
         with:
           github_token: ${{ secrets.SYS_EMF_GH_TOKEN }}
           project_folder: ${{ inputs.project_folder }}

--- a/.github/workflows/pre-merge-orch-ci.yml
+++ b/.github/workflows/pre-merge-orch-ci.yml
@@ -15,7 +15,7 @@ jobs:
   pre-merge:
     permissions:
       contents: read
-    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@6fd47d2a79b1e7d4988d1a5df6585b29a76f65c4  # 2026.1.1
+    uses: open-edge-platform/orch-ci/.github/workflows/pre-merge.yml@6fd47d2a79b1e7d4988d1a5df6585b29a76f65c4  # 2026.1.2
     with:
       run_version_check: true
       run_dep_version_check: false

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -284,7 +284,7 @@ jobs:
           path: ci
           persist-credentials: false
       - name: Gitleaks scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@ca0841de53d0e70b4934696601a748bff06fe6d9  # 2026.1.1
+        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@6fd47d2a79b1e7d4988d1a5df6585b29a76f65c4  # 2026.1.2
         with:
           scan-scope: changed
           source: ${INPUTS_PROJECT_FOLDER}
@@ -410,7 +410,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Bandit scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@ca0841de53d0e70b4934696601a748bff06fe6d9  # 2026.1.1
+        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@6fd47d2a79b1e7d4988d1a5df6585b29a76f65c4  # 2026.1.2
         with:
           scan-scope: "changed"
           severity-level: "HIGH"

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -164,7 +164,7 @@ jobs:
           path: ci
           persist-credentials: false
       - name: Gitleaks scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@b5930c48c1fcdb6b34ffbcd465cff96dabfbde70  # 2026.0.17
+        uses: open-edge-platform/orch-ci/.github/actions/security/gitleaks@6fd47d2a79b1e7d4988d1a5df6585b29a76f65c4  # 2026.1.2
         with:
           scan-scope: changed
           source: ${INPUTS_PROJECT_FOLDER}
@@ -414,7 +414,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Run Bandit scan
-        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@b5930c48c1fcdb6b34ffbcd465cff96dabfbde70  # 2026.0.17
+        uses: open-edge-platform/orch-ci/.github/actions/security/bandit@6fd47d2a79b1e7d4988d1a5df6585b29a76f65c4  # 2026.1.2
         with:
           scan-scope: "changed"
           severity-level: "HIGH"


### PR DESCRIPTION
This pull request updates several GitHub Actions and workflow references to use the latest `2026.1.2` version of the `open-edge-platform/orch-ci` actions and workflows. These updates ensure that the CI/CD pipelines are using the most recent features and security fixes.

**Workflow action updates:**

* Updated the `pr_updater` action in `.github/workflows/auto-update.yml` to version `2026.1.2` for improved pull request management.
* Updated the `pre-merge.yml` workflow reference in `.github/workflows/pre-merge-orch-ci.yml` to version `2026.1.2` for consistency with the latest upstream changes.

**Security scanning updates:**

* Updated the `Gitleaks` and `Bandit` security scanning actions in both `.github/workflows/pre-merge.yml` and `.github/workflows/post-merge.yml` to version `2026.1.2`, ensuring the latest security checks are applied during pre-merge and post-merge phases. [[1]](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109L287-R287) [[2]](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109L413-R413) [[3]](diffhunk://#diff-649dadd84b5d9938ac7f7a33a4020062fa437edcfc320554adf8bcf62c14602aL323-R323) [[4]](diffhunk://#diff-649dadd84b5d9938ac7f7a33a4020062fa437edcfc320554adf8bcf62c14602aL367-R367)