### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge-orch-ci.yml
+++ b/.github/workflows/post-merge-orch-ci.yml
@@ -8,6 +8,8 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
+    tags:
+      - '*'
   workflow_dispatch:
 
 # Global minimal permissions


### PR DESCRIPTION
This pull request makes a small configuration change to the GitHub Actions workflow. It updates the workflow trigger so that it now runs not only on pushes to the `main` branch but also on any tag push.

* [`.github/workflows/post-merge-orch-ci.yml`](diffhunk://#diff-0a5a64b064f5769632bf0cc68a558f3ff765211cd721e394ecc03523e74bf704R11-R12): Updated the workflow trigger to run on tag pushes in addition to pushes to the `main` branch.# Pull Request Template

<!---
  SPDX-FileCopyrightText: (C) 2026 Intel Corporation
  SPDX-License-Identifier: Apache-2.0

  ------------------------------------------------------

  Author Mandatory (to be filled by PR Author/Submitter)
  ------------------------------------------------------

  - Developer who submits the Pull Request for merge is required to mark the
    checklist below as applicable for the PR changes submitted.
  - Those checklist items which are not marked are considered as not applicable
    for the PR change.
-->

## Description

Please include a summary of the changes and the related issue. List any dependencies
that are required for this change.

Fixes # (issue)

## Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change.
List their name, license information, and how they are used in the project.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions
so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist

- [ ] I agree to use the APACHE-2.0 license for my code changes
- [ ] I have not introduced any 3rd party dependency changes
- [ ] I have performed a self-review of my code
