### PR TITLE
Update bandit action.yml configuration

### DIFF
--- a/.github/actions/security/bandit/action.yml
+++ b/.github/actions/security/bandit/action.yml
@@ -185,7 +185,7 @@ runs:
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
       with:
         name: bandit-results-${{ steps.run-bandit.outputs.rand_suffix }}${{ env.suffix }}
-        path: "${REPORT_PATH}"
+        path: "${{ env.REPORT_PATH }}"
         retention-days: 7
 
     - name: Fix SARIF severity levels


### PR DESCRIPTION
This pull request makes a small update to the Bandit security scan GitHub Action configuration. The change ensures that the `REPORT_PATH` variable is referenced correctly as an environment variable in the artifact upload step. 

([.github/actions/security/bandit/action.ymlL188-R188](diffhunk://#diff-9cf2145e356c42c4c56abf0eac4bc14039ea80fc9e5d96ccd490714457698b35L188-R188))


Jira: https://jira.devtools.intel.com/browse/ITEP-92432
Initial observed error: https://github.com/open-edge-platform/dlstreamer/actions/runs/26225160100/job/77170117070