### PR TITLE
Input parameter for run repo pipeline post-merge workflow

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -9,6 +9,11 @@ name: Post-Merge CI Pipeline
 on:  # yamllint disable-line rule:truthy
   workflow_call:
     inputs:
+      run_repo_pipeline:
+        description: "Run default pipeline checks"
+        required: false
+        default: true
+        type: boolean
       run_version_check:
         description: "Run version check"
         required: false
@@ -381,6 +386,7 @@ jobs:
           scan-scope: "all"
           fail-on-findings: false
   run-repo-pipelines:
+    if: ${{ inputs.run_repo_pipeline }}
     permissions:
       contents: read
     runs-on: ${{ inputs.runs_on }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/post-merge.yml` workflow to make the execution of the repository pipeline checks configurable via an input parameter. This allows users to optionally skip the default pipeline checks when triggering the workflow.

Workflow configuration improvements:

* Added a new boolean input parameter `run_repo_pipeline` to the workflow, allowing callers to control whether the default pipeline checks are run. The parameter defaults to `true`.
* Updated the `run-repo-pipelines` job to only run if `run_repo_pipeline` is set to `true`, making the job conditional based on the new input.