### PR TITLE
Added Trivy CIS Compliance scan to Post-merge

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1008,6 +1008,57 @@ jobs:
           sanitized_image_name="${sanitized_image_name//[:\/]/_}"
           echo "sanitized_image_name=$sanitized_image_name" >> "$GITHUB_ENV"
 
+      - name: Prepare Trivy CIS artifact name
+        env:
+          IMAGE: ${{ matrix.image }}
+        id: trivy-artifact
+        run: |
+          set -euo pipefail
+          SANITIZED_NAME=$(echo "$IMAGE" | tr ':/.@' '_' | tr -cd '[:alnum:]_-')
+          IMAGE_HASH=$(echo -n "$IMAGE" | sha1sum | awk '{print $1}')
+          ARTIFACT_NAME="trivy-cis-${SANITIZED_NAME}-${IMAGE_HASH:0:8}"
+          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Load tool versions (safe)
+        shell: bash
+        run: |
+          echo "TRIVY_VER=0.69.3" >> "$GITHUB_ENV"
+
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@3fb12ec12f41e471780db15c232d5dd185dcb514  # v0.2.5
+        with:
+          version: 'v${{ env.TRIVY_VER }}'
+
+      - name: Scan Image for Docker CIS compliance
+        continue-on-error: true
+        env:
+          SANITIZED_IMAGE_NAME: ${{ env.sanitized_image_name }}
+          IMAGE: ${{ matrix.image }}
+        run: |
+          trivy image \
+            --compliance docker-cis-1.6.0 \
+            --format table \
+            --output "trivy_cis-${SANITIZED_IMAGE_NAME}.txt" \
+            "$IMAGE"
+
+          if grep -E '│ *(HIGH|CRITICAL) *│.*│ *FAIL *│' trivy_cis-${SANITIZED_IMAGE_NAME}.txt; then
+            echo "❌ Found HIGH/CRITICAL CIS failures"
+            cat trivy_cis-${SANITIZED_IMAGE_NAME}.txt
+            exit 1
+          else
+            echo "✅ No HIGH/CRITICAL CIS failures"
+          fi
+
+      - name: Upload CIS Scan Report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        env:
+          SANITIZED_IMAGE_NAME: ${{ env.sanitized_image_name }}
+        with:
+          name: ${{ steps.trivy-artifact.outputs.artifact_name }}
+          path: trivy_cis-${SANITIZED_IMAGE_NAME}.txt
+          if-no-files-found: warn
+
       - name: Scan Image
         env:
           SANITIZED_IMAGE_NAME: ${{ env.sanitized_image_name }}


### PR DESCRIPTION
This pull request adds a Docker CIS compliance scan using Trivy to the `post-merge.yml` GitHub Actions workflow. The new steps install Trivy, perform a CIS scan on each image, fail the step if HIGH or CRITICAL CIS failures are found, and upload the scan report as an artifact.

**Security and compliance scanning:**

* Added steps to install Trivy, run a Docker CIS 1.6.0 compliance scan on each image in the workflow, and fail the step if HIGH or CRITICAL CIS failures are detected.
* Created a unique artifact name for each scan report using a sanitized image name and hash, and uploaded the CIS scan report as a workflow artifact.