### PR TITLE
Configure Dependabot to run weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "
@@ -19,7 +19,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/bootstrap"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 2
     commit-message:
       prefix: "[gha-bootstrap] "
@@ -29,7 +29,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/clamav"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 2
     commit-message:
       prefix: "[gha-clamav] "
@@ -39,7 +39,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/pr_updater"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 2
     commit-message:
       prefix: "[gha-pr-updater] "
@@ -49,7 +49,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/.github/actions/security"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 2
     commit-message:
       prefix: "[gha-security] "
@@ -60,7 +60,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/dev-version-update"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 2
     commit-message:
       prefix: "[gha-dev-version] "
@@ -70,7 +70,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/discover-changed-files"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 2
     commit-message:
       prefix: "[gha-changed-files] "
@@ -80,7 +80,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/discover-changed-subfolders"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 2
     commit-message:
       prefix: "[gha-changed-subfolders] "
@@ -90,7 +90,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/verify-branch-name"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 2
     commit-message:
       prefix: "[gha-verify-branch] "


### PR DESCRIPTION
This pull request updates the Dependabot configuration to reduce the frequency of update checks for all GitHub Actions-related dependencies from daily to weekly. This change helps to minimize the noise from frequent pull requests while still ensuring dependencies are kept up to date.

Dependabot schedule changes:

* Changed the update interval from daily to weekly for the main GitHub Actions workflow in the root directory (`.github/dependabot.yml`).
* Changed the update interval from daily to weekly for the following GitHub Actions subdirectories:
  - `/ .github/actions/bootstrap`
  - `/ .github/actions/clamav`
  - `/ .github/actions/pr_updater`
  - `/ .github/actions/security`
  - `/dev-version-update`
  - `/discover-changed-files`
  - `/discover-changed-subfolders`
  - `/verify-branch-name`