### PR TITLE
Updated Semgrep action.yml

### DIFF
--- a/.github/actions/security/semgrep/action.yml
+++ b/.github/actions/security/semgrep/action.yml
@@ -94,6 +94,10 @@ inputs:
     description: "In case of matrix jobs pass a suffix with the job name with a -"
     required: false
     default: ""
+  semgrep-extra-args:
+    description: "Extra arguments passed directly to semgrep CLI"
+    required: false
+    default: ""
   upload-sarif:
     description: "Whether to upload SARIF results to the GitHub Security tab"
     required: false
@@ -124,6 +128,7 @@ runs:
       # Set the SEMGREP_RULES environment variable to specify which rules Semgrep should use.
       env:
         SEMGREP_RULES: ${{ inputs.config }}
+        INPUTS_SEMGREP_EXTRA_ARGS: ${{ inputs.semgrep-extra-args }}
         INPUTS_SCAN_SCOPE: ${{ inputs.scan-scope }}
         INPUTS_PATHS: ${{ inputs.paths }}
         INPUTS_SEVERITY: ${{ inputs.severity }}
@@ -175,6 +180,7 @@ runs:
           ${SEMGREP_SEVERITY} \
           --error \
           --metrics=off \
+          $INPUTS_SEMGREP_EXTRA_ARGS \
           --timeout "$INPUTS_TIMEOUT" \
           --"$INPUTS_OUTPUT_FORMAT" \
           -o "${REPORT_FILE}" \


### PR DESCRIPTION
This pull request updates the Semgrep GitHub Action to allow passing additional CLI arguments directly to Semgrep, making the action more flexible for different use cases.

**Enhancements to Semgrep GitHub Action:**

* Added a new input `semgrep-extra-args` to `action.yml` to allow users to specify extra arguments for the Semgrep CLI, with a default value of an empty string.
* Passed the value of `semgrep-extra-args` as an environment variable (`INPUTS_SEMGREP_EXTRA_ARGS`) to the action runner.
* Updated the Semgrep execution command to include any extra arguments specified via `semgrep-extra-args`.
