### PR TITLE
fix(security): make security scans blocking by default and add govuln…

### DIFF
--- a/.github/actions/security/gitleaks/action.yml
+++ b/.github/actions/security/gitleaks/action.yml
@@ -252,9 +252,8 @@ runs:
           exit 1
         fi
         echo "exit_code=$STATUS" >> "$GITHUB_OUTPUT"
-        # Don't hard-fail the job; let the caller decide based on outputs.exit_code
         if [[ "$STATUS" -ne 0 ]]; then
-          echo "::warning::Gitleaks detected leaks (exit code $STATUS)"
+          echo "::error::Gitleaks detected leaks (exit code $STATUS)"
         fi
 
     - name: Fix SARIF endColumn values for GitHub validation
@@ -293,3 +292,10 @@ runs:
       uses: github/codeql-action/upload-sarif@b1bff81932f5cdfc8695c7752dcee935dcd061c8  # v4.33.0
       with:
         sarif_file: ${{ steps.run-gitleaks.outputs.report_path }}
+
+    - name: Fail on gitleaks findings
+      if: steps.run-gitleaks.outputs.exit_code != '0'
+      shell: bash
+      run: |
+        echo "::error::Gitleaks detected leaks. SARIF uploaded to Security tab."
+        exit 1

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -14,6 +14,14 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: true
         type: boolean
+      security_scans_advisory:
+        description: >-
+          Run security scans in advisory mode (non-blocking). Default false = scans block.
+          Consumers with active vulnerability backlogs may set true temporarily; expected to
+          be removed in a future release.
+        required: false
+        default: false
+        type: boolean
       run_version_check:
         description: "Run version check"
         required: false
@@ -356,7 +364,7 @@ jobs:
           redact: "true"
           report_suffix: "-${{ env.SANITIZED_PROJECT_NAME }}"
           upload-sarif: "true"
-          exit_code_on_leak: "0"
+          exit_code_on_leak: "1"
   zizmor-scan:
     permissions:
       security-events: write
@@ -628,7 +636,7 @@ jobs:
       - name: Lint Code
         if: ${{ inputs.run_lint }}
         working-directory: ${{ inputs.project_folder }}
-        continue-on-error: true
+        continue-on-error: ${{ inputs.security_scans_advisory }}
         run: |
           make lint
 
@@ -1084,7 +1092,7 @@ jobs:
           version: 'v${{ env.TRIVY_VER }}'
 
       - name: Scan Image for Docker CIS compliance
-        continue-on-error: true
+        continue-on-error: ${{ inputs.security_scans_advisory }}
         env:
           SANITIZED_IMAGE_NAME: ${{ env.sanitized_image_name }}
           IMAGE: ${{ matrix.image }}

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -15,6 +15,24 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: false
         type: boolean
+      run_govulncheck:
+        description: "Run govulncheck against the Go module for reachable vulnerable dependencies"
+        required: false
+        default: false
+        type: boolean
+      go_version:
+        description: "Go version passed to govulncheck (e.g. '1.25', 'stable')"
+        required: false
+        default: "stable"
+        type: string
+      security_scans_advisory:
+        description: >-
+          Run security scans in advisory mode (non-blocking). Default false = scans block PRs.
+          Consumers with active vulnerability backlogs may set true temporarily; expected to
+          be removed in a future release.
+        required: false
+        default: false
+        type: boolean
       run_version_check:
         description: "Run version check"
         required: false
@@ -245,9 +263,14 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
       - name: Run zizmor
-        run: uvx zizmor=="$ZIZMOR_VERSION" "$GITHUB_WORKSPACE" --no-exit-codes > zizmor_scan_report.txt
+        continue-on-error: ${{ inputs.security_scans_advisory }}
+        run: |
+          set -o pipefail
+          uvx zizmor=="$ZIZMOR_VERSION" --min-severity=high "$GITHUB_WORKSPACE" \
+            | tee zizmor_scan_report.txt
       - name: Upload Zizmor Scan Report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        if: always()
         with:
           name: zizmor-scan-report-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}
           path: zizmor_scan_report.txt
@@ -307,13 +330,13 @@ jobs:
           persist-credentials: false
       - name: Run Trivy Filesystem Scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
-        continue-on-error: true
+        continue-on-error: ${{ inputs.security_scans_advisory }}
         with:
           scan-type: 'fs'
           scan-ref: ${{ inputs.project_folder }}
           format: 'sarif'
           severity: 'HIGH,CRITICAL'
-          ignore-unfixed: true
+          ignore-unfixed: false
           trivy-config: ${{ inputs.trivy_config_path }}
           scanners: 'vuln,secret'
           output: "trivy_scan_report-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}.sarif"
@@ -335,7 +358,7 @@ jobs:
           && mv trivy_tagged.sarif trivy_scan_report-${SANITIZED_PROJECT_NAME}.sarif
 
       - name: Trivy FS Verdict
-        continue-on-error: true
+        continue-on-error: ${{ inputs.security_scans_advisory }}
         env:
           SANITIZED_PROJECT_NAME: ${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}
         run: |
@@ -364,7 +387,7 @@ jobs:
 
       - name: Run Trivy Config Scan (Dockerfile / IaC)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # 0.36.0
-        continue-on-error: true
+        continue-on-error: ${{ inputs.security_scans_advisory }}
         with:
           scan-type: 'config'
           scan-ref: ${{ inputs.project_folder }}
@@ -390,7 +413,7 @@ jobs:
           && mv trivy_tagged.sarif trivy-config-${SANITIZED_PROJECT_NAME}.sarif
 
       - name: Trivy Config Verdict
-        continue-on-error: true
+        continue-on-error: ${{ inputs.security_scans_advisory }}
         env:
           SANITIZED_PROJECT_NAME: ${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}
         run: |
@@ -425,6 +448,24 @@ jobs:
           confidence-level: "HIGH"
           output-format: "txt"
           upload-sarif: "false"
+
+  govulncheck:
+    if: ${{ inputs.run_security_scans && inputs.run_govulncheck }}
+    permissions:
+      contents: read
+    runs-on: ${{ inputs.runs_on }}
+    needs: sanitize-project-folder
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run govulncheck
+        continue-on-error: ${{ inputs.security_scans_advisory }}
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee  # v1.0.4
+        with:
+          go-version-input: ${{ inputs.go_version }}
+          work-dir: ${{ inputs.project_folder }}
   run-repo-pipelines:
     permissions:
       contents: read
@@ -556,7 +597,7 @@ jobs:
       - name: Lint Code
         if: ${{ inputs.run_lint }}
         working-directory: ${{ inputs.project_folder }}
-        continue-on-error: true
+        continue-on-error: ${{ inputs.security_scans_advisory }}
         env:
           MAKEFLAGS: ${{ inputs.lint_makeflags }}
         run: |
@@ -844,7 +885,7 @@ jobs:
           version: 'v${{ env.TRIVY_VER }}'
 
       - name: Scan Image for Docker CIS compliance
-        continue-on-error: true
+        continue-on-error: ${{ inputs.security_scans_advisory }}
         env:
           SANITIZED_IMAGE_NAME: ${{ env.sanitized_image_name }}
           IMAGE: ${{ matrix.image }}
@@ -879,7 +920,7 @@ jobs:
           persist-credentials: false
 
       - name: Scan Image for High/Critical Issues (Trivy)
-        continue-on-error: true
+        continue-on-error: ${{ inputs.security_scans_advisory }}
         env:
           TRIVY_CONFIG: ${{ inputs.trivy_config_path }}
           IMAGE: ${{ matrix.image }}

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -14,6 +14,14 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: false
         type: boolean
+      security_scans_advisory:
+        description: >-
+          Run security scans in advisory mode (non-blocking). Default false = scans block PRs.
+          Consumers with active vulnerability backlogs may set true temporarily; expected to
+          be removed in a future release.
+        required: false
+        default: false
+        type: boolean
       pre_merge_scan:
         description: "Run security scans for pre-merge workflows"
         required: false
@@ -127,9 +135,14 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
       - name: Run zizmor
-        run: uvx zizmor=="$ZIZMOR_VERSION" "$GITHUB_WORKSPACE" --no-exit-codes > zizmor_scan_report.txt
+        continue-on-error: ${{ inputs.security_scans_advisory }}
+        run: |
+          set -o pipefail
+          uvx zizmor=="$ZIZMOR_VERSION" --min-severity=high "$GITHUB_WORKSPACE" \
+            | tee zizmor_scan_report.txt
       - name: Upload Zizmor Scan Report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        if: always()
         with:
           name: zizmor-scan-report-${{ needs.sanitize-project-folder.outputs.sanitized_project_name }}
           path: zizmor_scan_report.txt


### PR DESCRIPTION
## Description

Fixes a class of CI/CD security-scanner issues raised in a recent downstream security review. Root cause across all findings: every security scanner in the reusable pre-merge, post-merge, and security-scans workflows was configured in advisory mode — `continue-on-error: true`, `--no-exit-codes`, or `exit_code_on_leak: "0"` — so scanner findings were reported to logs and SARIF artifacts but never failed the job. Repos calling into `orch-ci` therefore inherited green CI checks even when scanners detected HIGH/CRITICAL issues, which explains why cleaned-up vulnerabilities kept returning.

Because `orch-ci` is a fan-in shared workflow, this PR introduces a new `security_scans_advisory` input (default `false` = blocking) rather than flipping every calling repo overnight. Calling repos with an active vulnerability backlog can opt into a temporary grace window by setting the input to `true` while they remediate. The input is expected to be removed in a follow-up release once callers migrate.

The PR also introduces a new `govulncheck` job for Go repos to close a gap where the reusable pipeline had no Go-specific dependency vulnerability gate.

### Changes

- **`.github/workflows/pre-merge.yml`**
  - New inputs: `security_scans_advisory: bool` (default `false`), `run_govulncheck: bool` (default `false`, opt-in per calling repo), `go_version: string` (default `stable`).
  - Trivy filesystem scan: `continue-on-error: true` → `${{ inputs.security_scans_advisory }}` on both the scan step and the SARIF-verdict step; `ignore-unfixed: true` → `false` so unfixed HIGH/CRITICAL CVEs surface.
  - Trivy config scan (Dockerfile/IaC): same `continue-on-error` gating on scan and verdict.
  - Zizmor: dropped `--no-exit-codes`, replaced the exit-code-swallowing `> report.txt` redirection with `set -o pipefail; ... | tee report.txt` so the tool's exit code propagates; added `--min-severity=high`; upload of the Zizmor report is now `if: always()` so triage still has the artifact when the scan fails.
  - `make lint` step: `continue-on-error` gated on the new input.
  - Docker CIS scan and Trivy image scan: `continue-on-error` gated on the new input.
  - New job `govulncheck` gated on `inputs.run_security_scans && inputs.run_govulncheck`, runs `golang/govulncheck-action` pinned by SHA, `continue-on-error` gated on the advisory input.

- **`.github/workflows/security-scans.yml`**
  - New `security_scans_advisory` input.
  - Zizmor invocation updated identically to `pre-merge.yml` (drop `--no-exit-codes`, `tee`+`pipefail`, `--min-severity=high`).

- **`.github/workflows/post-merge.yml`**
  - New `security_scans_advisory` input.
  - Gitleaks caller step: `exit_code_on_leak: "0"` → `"1"` so a leaked secret merged to `main` now fails the post-merge run.
  - `make lint` step and Docker CIS scan: `continue-on-error` gated on the new input.

- **`.github/actions/security/gitleaks/action.yml`**
  - Removed the deliberate "don't hard-fail the job" behavior. Composite action now exits with the gitleaks return code and emits `::error::` on findings. Callers wanting advisory behavior must explicitly set `exit_code_on_leak: "0"`, which is auditable in the workflow file.

### Impact on calling repos

- **Default behavior:** every calling repo inherits blocking security scans on the next SHA-pin bump. No caller-side changes required.
- **Grace window:** repos with vulnerability backlogs can pass `security_scans_advisory: true` in their `with:` block to keep advisory mode temporarily. Expected to be removed in a future release once callers migrate.
- **Go repos:** pass `run_govulncheck: true` (and optionally `go_version:`) to opt into the new Go dependency vulnerability gate.

Companion downstream PR (already open) taking the same fix locally in `image-composer-tool`: [open-edge-platform/image-composer-tool#871](https://github.com/open-edge-platform/image-composer-tool/pull/871). Independent — no merge-order dependency.

Fixes # (n/a — findings tracked out-of-band with the security reviewer)

## Any Newly Introduced Dependencies

- **`golang/govulncheck-action@v1.0.4`** — official Go team GitHub Action wrapping the `govulncheck` CLI. Pinned by full commit SHA. Used only in the new opt-in `govulncheck` job. License: BSD-3-Clause. Consumes the Go vulnerability database at `pkg.go.dev/vuln` (Google-hosted, curated by the Go security team).

No other third-party actions or scanners introduced. All other changes are to already-present tooling (Trivy, Zizmor, Gitleaks, `make lint`, CIS scan).

## How Has This Been Tested?

- **YAML syntax:** validated all four changed files parse with `python3 -c "import yaml; yaml.safe_load(open('<file>'))"`.
- **Grep verification** across `.github/`:
  - `continue-on-error: true` — zero matches remain in security-scan contexts.
  - `--no-exit-codes` — zero matches remain.
  - `exit_code_on_leak: "0"` — zero matches remain.
- **Input default preserves the intended new behavior for a calling repo that doesn't upgrade explicitly:** `security_scans_advisory` defaults to `false`, so once a caller bumps its SHA pin without setting the input, it gets blocking behavior — which is the intended outcome.
- **Input opt-out preserves the previous soft behavior for callers that need it:** setting `security_scans_advisory: true` reproduces the pre-PR advisory mode for all gated steps (verified by inspecting each `continue-on-error: ${{ inputs.security_scans_advisory }}` site).
- Full pipeline behavior on a real Go caller will be validated by the downstream ICT companion PR once this PR merges and ICT bumps its SHA pin.
